### PR TITLE
Fix(scripts): Correct NameError in prepare_ocr_dataset.py

### DIFF
--- a/cultural_artifact_explorer/scripts/prepare_ocr_dataset.py
+++ b/cultural_artifact_explorer/scripts/prepare_ocr_dataset.py
@@ -128,14 +128,15 @@ def update_ocr_config(config_path, dataset_path, annotations_path, char_list_pat
 
     # Ensure the directory exists before writing the file
     os.makedirs(os.path.dirname(config_path), exist_ok=True)
+
     # Write the updated config back to the file
     with open(config_path, 'w') as f:
         yaml.dump(config_data, f, sort_keys=False)
 
     print(f"\nSuccessfully updated '{config_path}' with the new dataset paths.")
-    print("  training.dataset_path ->", rel_dataset_path)
-    print("  training.annotations_file ->", rel_annotations_path)
-    print("  model.char_list_path ->", rel_char_list_path)
+    print("  training.dataset_path ->", abs_dataset_path)
+    print("  training.annotations_file ->", abs_annotations_path)
+    print("  model.char_list_path ->", abs_char_list_path)
 
 
 def main():

--- a/cultural_artifact_explorer/src/nlp/ner.py
+++ b/cultural_artifact_explorer/src/nlp/ner.py
@@ -9,6 +9,7 @@ import os
 # Import model and utilities from our source files
 from .model_definition_ner import BiLSTM_CRF
 from .utils import preprocess_text_for_nlp # Optional preprocessing
+
 class NERTagger:
     def __init__(self, config_path):
         """


### PR DESCRIPTION
- The script was failing with a `NameError` because the print statements at the end of the `update_ocr_config` function were still referring to the old `rel_..._path` variables after they had been renamed to `abs_..._path`.
- This commit corrects the variable names in the print statements, resolving the crash.