### PR TITLE
I added a print statement to the `OCRDataset` class in `src/ocr/datas…

### DIFF
--- a/cultural_artifact_explorer/src/ocr/dataset.py
+++ b/cultural_artifact_explorer/src/ocr/dataset.py
@@ -41,7 +41,7 @@ class OCRDataset(Dataset):
 
         try:
             self.annotations = pd.read_csv(annotations_file, keep_default_na=False)
-            print(f"  Loaded {len(self.annotations)} annotations.")
+            print(f"  Loaded {len(self.annotations)} annotations. Columns: {self.annotations.columns.tolist()}")
         except Exception as e:
             print(f"Error loading or parsing annotation file {annotations_file}: {e}")
             self.annotations = pd.DataFrame(columns=['filepath', 'text'])


### PR DESCRIPTION
…et.py` to help diagnose a persistent `KeyError: 'filepath'`. This will print the column headers of the loaded annotations CSV at runtime, helping to verify if the 'filepath' column is being correctly read by pandas.